### PR TITLE
Add more extensions and support for comments

### DIFF
--- a/Syntaxes/Powerbuilder.tmLanguage
+++ b/Syntaxes/Powerbuilder.tmLanguage
@@ -39,6 +39,14 @@
 		</dict>
 		<dict>
 			<key>begin</key>
+			<string>#</string>
+			<key>end</key>
+			<string>$</string>
+			<key>name</key>
+			<string>comment.line.hash.asp</string>
+		</dict>
+		<dict>
+			<key>begin</key>
 			<string>/\*</string>
 			<key>end</key>
 			<string>\*/</string>

--- a/Syntaxes/Powerbuilder.tmLanguage
+++ b/Syntaxes/Powerbuilder.tmLanguage
@@ -30,6 +30,22 @@
 			<string>meta.ending-space</string>
 		</dict>
 		<dict>
+			<key>begin</key>
+			<string>//</string>
+			<key>end</key>
+			<string>$</string>
+			<key>name</key>
+			<string>comment.line.double-slash.asp</string>
+		</dict>
+		<dict>
+			<key>begin</key>
+			<string>/\*</string>
+			<key>end</key>
+			<string>\*/</string>
+			<key>name</key>
+			<string>comment.block.asp</string>
+		</dict>
+		<dict>
 			<key>include</key>
 			<string>#round-brackets</string>
 		</dict>

--- a/Syntaxes/Powerbuilder.tmLanguage
+++ b/Syntaxes/Powerbuilder.tmLanguage
@@ -12,6 +12,8 @@
 		<string>sru</string>
 		<string>srw</string>
 		<string>srf</string>
+		<string>pbl</string>
+		<string>pbt</string>
 	</array>
 	<key>foldingStartMarker</key>
 	<string>(&lt;(?i:(head|table|div|style|script|ul|ol|form|dl))\b.*?&gt;|\{|^\s*&lt;?%?\s*'?\s*(?i:(sub|private\s+Sub|public\s+Sub|function|if|while|For))\s*.*$)</string>


### PR DESCRIPTION
The same basic grammar rules seem to work fine for `.pbl` and `.pbt` files as well.
